### PR TITLE
Update Storage to fit Source Control

### DIFF
--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -5,6 +5,10 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 
 import javafx.collections.ObservableList;
+import seedu.address.model.student.Assessment;
+import seedu.address.model.student.AssessmentList;
+import seedu.address.model.student.Group;
+import seedu.address.model.student.GroupList;
 import seedu.address.model.student.Student;
 import seedu.address.model.student.UniqueStudentList;
 
@@ -15,6 +19,8 @@ import seedu.address.model.student.UniqueStudentList;
 public class AddressBook implements ReadOnlyAddressBook {
 
     private final UniqueStudentList students;
+    private final GroupList groups;
+    private final AssessmentList assessments;
 
     /*
      * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
@@ -25,6 +31,8 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     {
         students = new UniqueStudentList();
+        groups = new GroupList();
+        assessments = new AssessmentList();
     }
 
     public AddressBook() {}
@@ -70,8 +78,8 @@ public class AddressBook implements ReadOnlyAddressBook {
      * Adds a student to the address book.
      * The student must not already exist in the address book.
      */
-    public void addStudent(Student p) {
-        students.add(p);
+    public void addStudent(Student s) {
+        students.add(s);
     }
 
     /**
@@ -94,6 +102,42 @@ public class AddressBook implements ReadOnlyAddressBook {
         students.remove(key);
     }
 
+    //// group-level operations
+
+    /**
+     * Returns true if a group with the same identity as {@code group} exists in the address book.
+     */
+    public boolean hasGroup(Group group) {
+        requireNonNull(group);
+        return groups.contains(group);
+    }
+
+    /**
+     * Adds a group to the address book.
+     * The group must not already exist in the address book.
+     */
+    public void addGroup(Group g) {
+        groups.add(g);
+    }
+
+    //// assessment-level operations
+
+    /**
+     * Returns true if an assessment with the same identity as {@code assessment} exists in the address book.
+     */
+    public boolean hasAssessment(Assessment assessment) {
+        requireNonNull(assessment);
+        return assessments.contains(assessment);
+    }
+
+    /**
+     * Adds an assessment to the address book.
+     * The assessment must not already exist in the address book.
+     */
+    public void addAssessment(Assessment a) {
+        assessments.add(a);
+    }
+
     //// util methods
 
     @Override
@@ -108,14 +152,28 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     @Override
+    public List<Group> getGroupList() {
+        return groups.groups;
+    }
+
+    @Override
+    public List<Assessment> getAssessmentList() {
+        return assessments.assessments;
+    }
+
+    @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof AddressBook // instanceof handles nulls
-                && students.equals(((AddressBook) other).students));
+                && students.equals(((AddressBook) other).students)
+                && groups.equals(((AddressBook) other).groups)
+                && assessments.equals(((AddressBook) other).assessments));
     }
 
     @Override
     public int hashCode() {
-        return students.hashCode();
+        return (groups.hashCode() << 24)
+                + (assessments.hashCode() << 16)
+                + students.hashCode();
     }
 }

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -1,6 +1,10 @@
 package seedu.address.model;
 
+import java.util.List;
+
 import javafx.collections.ObservableList;
+import seedu.address.model.student.Assessment;
+import seedu.address.model.student.Group;
 import seedu.address.model.student.Student;
 
 /**
@@ -14,4 +18,13 @@ public interface ReadOnlyAddressBook {
      */
     ObservableList<Student> getStudentList();
 
+    /**
+     * Returns a list of groups.
+     */
+    List<Group> getGroupList();
+
+    /**
+     * Returns a list of assessments.
+     */
+    List<Assessment> getAssessmentList();
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedAssessment.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedAssessment.java
@@ -1,0 +1,64 @@
+package seedu.address.storage;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.student.Assessment;
+import seedu.address.model.student.ID;
+import seedu.address.model.student.Score;
+
+public class JsonAdaptedAssessment {
+    private final String assessmentName;
+    private final Map<String, String> scores;
+
+    /**
+     * Constructs a {@code JsonAdaptedAssessment} with the given {@code assessmentName}.
+     */
+    @JsonCreator
+    public JsonAdaptedAssessment(String assessmentName, Map<String, String> scores) {
+        this.assessmentName = assessmentName;
+        this.scores = scores;
+    }
+
+    /**
+     * Converts a given {@code Assessment} into this class for Jackson use.
+     */
+    public JsonAdaptedAssessment(Assessment source) {
+        assessmentName = source.value;
+        scores = new HashMap<>();
+        for (ID id : source.scores.keySet()) {
+            scores.put(id.value, source.scores.get(id).value);
+        }
+    }
+
+    @JsonValue
+    public String getAssessmentName() {
+        return assessmentName;
+    }
+
+    @JsonValue
+    public Map<String, String> getScores() {
+        return scores;
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted tag object into the model's {@code Assessment} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted assessment.
+     */
+    public Assessment toModelType() throws IllegalValueException {
+        if (!Assessment.isValidAssessment(assessmentName)) {
+            throw new IllegalValueException(Assessment.MESSAGE_CONSTRAINTS);
+        }
+
+        Assessment assessment = new Assessment(assessmentName);
+        for (String id : scores.keySet()) {
+            assessment.scores.put(new ID(id), new Score(scores.get(id)));
+        }
+        return assessment;
+    }
+}

--- a/src/main/java/seedu/address/storage/JsonAdaptedGroup.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedGroup.java
@@ -1,0 +1,43 @@
+package seedu.address.storage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.student.Group;
+
+public class JsonAdaptedGroup {
+    private final String groupName;
+
+    /**
+     * Constructs a {@code JsonAdaptedGroup} with the given {@code groupName}.
+     */
+    @JsonCreator
+    public JsonAdaptedGroup(String groupName) {
+        this.groupName = groupName;
+    }
+
+    /**
+     * Converts a given {@code Group} into this class for Jackson use.
+     */
+    public JsonAdaptedGroup(Group source) {
+        groupName = source.value;
+    }
+
+    @JsonValue
+    public String getGroupName() {
+        return groupName;
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted tag object into the model's {@code Group} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted group.
+     */
+    public Group toModelType() throws IllegalValueException {
+        if (!Group.isValidGroup(groupName)) {
+            throw new IllegalValueException(Group.MESSAGE_CONSTRAINTS);
+        }
+        return new Group(groupName);
+    }
+}

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -8,6 +8,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -17,6 +18,8 @@ import org.junit.jupiter.api.Test;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.model.student.Assessment;
+import seedu.address.model.student.Group;
 import seedu.address.model.student.Student;
 import seedu.address.model.student.exceptions.DuplicatePersonException;
 import seedu.address.testutil.PersonBuilder;
@@ -95,6 +98,16 @@ public class AddressBookTest {
         @Override
         public ObservableList<Student> getStudentList() {
             return students;
+        }
+
+        @Override
+        public List<Group> getGroupList() {
+            return new ArrayList<>();
+        }
+
+        @Override
+        public List<Assessment> getAssessmentList() {
+            return new ArrayList<>();
         }
     }
 

--- a/src/test/java/seedu/address/storage/JsonAdaptedAssessmentTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedAssessmentTest.java
@@ -1,0 +1,31 @@
+package seedu.address.storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalPersons.BENSON;
+
+import java.util.HashMap;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.student.Assessment;
+
+public class JsonAdaptedAssessmentTest {
+    // TODO: Make TypicalAssessments, then test with those
+    private static final String VALID_ASSESSMENT = BENSON.getScores().keySet().iterator().next().value;
+    private static final String INVALID_ASSESSMENT = "5";
+
+    @Test
+    public void toModelType_validAssessmentDetails_returnsGroup() throws Exception {
+        JsonAdaptedAssessment assessment = new JsonAdaptedAssessment(VALID_ASSESSMENT, new HashMap<>());
+        assertEquals(new Assessment(VALID_ASSESSMENT), assessment.toModelType());
+    }
+
+    @Test
+    public void toModelType_invalidAssessmentName_throwsIllegalValueException() {
+        JsonAdaptedAssessment assessment = new JsonAdaptedAssessment(INVALID_ASSESSMENT, new HashMap<>());
+        String expectedMessage = Assessment.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, assessment::toModelType);
+    }
+}

--- a/src/test/java/seedu/address/storage/JsonAdaptedGroupTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedGroupTest.java
@@ -1,0 +1,28 @@
+package seedu.address.storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalPersons.BENSON;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.student.Group;
+
+public class JsonAdaptedGroupTest {
+    private static final String VALID_GROUP = BENSON.getGroups().get(0).value;
+    private static final String INVALID_GROUP = "5";
+
+    @Test
+    public void toModelType_validGroupDetails_returnsGroup() throws Exception {
+        JsonAdaptedGroup group = new JsonAdaptedGroup(VALID_GROUP);
+        assertEquals(BENSON.getGroups().get(0), group.toModelType());
+    }
+
+    @Test
+    public void toModelType_invalidGroupName_throwsIllegalValueException() {
+        JsonAdaptedGroup group = new JsonAdaptedGroup(INVALID_GROUP);
+        String expectedMessage = Group.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, group::toModelType);
+    }
+}

--- a/src/test/java/seedu/address/storage/JsonAdaptedStudentTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedStudentTest.java
@@ -1,16 +1,16 @@
 package seedu.address.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.storage.JsonAdaptedStudent.MISSING_FIELD_MESSAGE_FORMAT;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.BENSON;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.exceptions.IllegalValueException;
@@ -18,93 +18,99 @@ import seedu.address.model.student.Assessment;
 import seedu.address.model.student.Group;
 import seedu.address.model.student.ID;
 import seedu.address.model.student.Name;
-import seedu.address.model.student.Score;
+import seedu.address.model.student.Student;
 
 public class JsonAdaptedStudentTest {
     private static final String INVALID_NAME = "R@chel";
     private static final String INVALID_ID = "E123";
     private static final String INVALID_GROUP = "5";
     private static final String INVALID_ASSESSMENT = "8";
-    private static final String INVALID_SCORE = "101";
     private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_NAME = BENSON.getName().toString();
     private static final String VALID_ID = BENSON.getId().toString();
-    // TODO: Replace with Jackson-friendly versions
-    private static final List<Group> VALID_GROUPS = BENSON.getGroups();
-    private static final Map<Assessment, Score> VALID_SCORES = BENSON.getScores();
-    private static final String VALID_ASSESSMENT = "P01";
-    private static final String VALID_SCORE = "100";
+    private static final List<String> VALID_GROUPS = BENSON.getGroups().stream()
+            .map(group -> group.value)
+            .collect(Collectors.toList());
+    private static final List<String> VALID_ASSESSMENTS = BENSON.getScores().keySet().stream()
+            .map(Assessment::getName)
+            .collect(Collectors.toList());
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
 
+    // TODO: Make a typical groups, typical assessments, and link them all together
+    private static final List<Group> GROUP_LIST = BENSON.getGroups();
+    private static final List<Assessment> ASSESSMENT_LIST = List.copyOf(BENSON.getScores().keySet());
+
+    @BeforeAll
+    static void beforeAll() {
+        ASSESSMENT_LIST.forEach(assessment ->
+                assessment.setScores(BENSON.getId(), BENSON.getScores().get(assessment)));
+    }
+
     @Test
     public void toModelType_validPersonDetails_returnsPerson() throws Exception {
         JsonAdaptedStudent student = new JsonAdaptedStudent(BENSON);
-        assertEquals(BENSON, student.toModelType());
+        assertEquals(BENSON, student.toModelType(GROUP_LIST, ASSESSMENT_LIST));
     }
 
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedStudent student =
-                new JsonAdaptedStudent(INVALID_NAME, VALID_ID, VALID_GROUPS, VALID_SCORES, VALID_TAGS);
+                new JsonAdaptedStudent(INVALID_NAME, VALID_ID, VALID_GROUPS, VALID_ASSESSMENTS, VALID_TAGS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
-        assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
+        assertThrows(IllegalValueException.class, expectedMessage, () ->
+                student.toModelType(GROUP_LIST, ASSESSMENT_LIST));
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedStudent student =
-                new JsonAdaptedStudent(null, VALID_ID, VALID_GROUPS, VALID_SCORES, VALID_TAGS);
+                new JsonAdaptedStudent(null, VALID_ID, VALID_GROUPS, VALID_ASSESSMENTS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
-        assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
+        assertThrows(IllegalValueException.class, expectedMessage, () ->
+                student.toModelType(GROUP_LIST, ASSESSMENT_LIST));
     }
 
     @Test
     public void toModelType_invalidId_throwsIllegalValueException() {
         JsonAdaptedStudent student =
-                new JsonAdaptedStudent(VALID_NAME, INVALID_ID, VALID_GROUPS, VALID_SCORES, VALID_TAGS);
+                new JsonAdaptedStudent(VALID_NAME, INVALID_ID, VALID_GROUPS, VALID_ASSESSMENTS, VALID_TAGS);
         String expectedMessage = ID.MESSAGE_CONSTRAINTS;
-        assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
+        assertThrows(IllegalValueException.class, expectedMessage, () ->
+                student.toModelType(GROUP_LIST, ASSESSMENT_LIST));
     }
 
     @Test
     public void toModelType_nullId_throwsIllegalValueException() {
         JsonAdaptedStudent student =
-                new JsonAdaptedStudent(VALID_NAME, null, VALID_GROUPS, VALID_SCORES, VALID_TAGS);
+                new JsonAdaptedStudent(VALID_NAME, null, VALID_GROUPS, VALID_ASSESSMENTS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, ID.class.getSimpleName());
-        assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
+        assertThrows(IllegalValueException.class, expectedMessage, () ->
+                student.toModelType(GROUP_LIST, ASSESSMENT_LIST));
     }
 
     @Test
-    public void toModelType_invalidGroups_throwsIllegalValueException() {
-        // TODO: Replace with JsonAdaptedX
-        List<Group> invalidGroups = new ArrayList<>(VALID_GROUPS);
-        invalidGroups.add(new Group(INVALID_GROUP));
+    public void toModelType_invalidGroups_notAddedToPerson() throws IllegalValueException {
+        List<String> invalidGroups = new ArrayList<>(VALID_GROUPS);
+        invalidGroups.add(INVALID_GROUP);
         JsonAdaptedStudent student =
-                new JsonAdaptedStudent(VALID_NAME, VALID_ID, invalidGroups, VALID_SCORES, VALID_TAGS);
-        assertThrows(IllegalValueException.class, student::toModelType);
+                new JsonAdaptedStudent(VALID_NAME, VALID_ID, invalidGroups, VALID_ASSESSMENTS, VALID_TAGS);
+        Student modelStudent = student.toModelType(GROUP_LIST, ASSESSMENT_LIST);
+        assertTrue(modelStudent.getGroups().stream()
+                .noneMatch(group -> group.value.equals(INVALID_GROUP)));
     }
 
     @Test
-    public void toModelType_invalidAssessment_throwsIllegalValueException() {
-        // TODO: Replace with JsonAdaptedX
-        Map<Assessment, Score> invalidScores = new HashMap<>(VALID_SCORES);
-        invalidScores.put(new Assessment(INVALID_ASSESSMENT), new Score(VALID_SCORE));
+    public void toModelType_invalidAssessment_notAddedToPerson() throws IllegalValueException {
+        List<String> invalidAssessments = new ArrayList<>(VALID_ASSESSMENTS);
+        invalidAssessments.add(INVALID_ASSESSMENT);
         JsonAdaptedStudent student =
-                new JsonAdaptedStudent(VALID_NAME, VALID_ID, VALID_GROUPS, invalidScores, VALID_TAGS);
-        assertThrows(IllegalValueException.class, student::toModelType);
-    }
-
-    @Test
-    public void toModelType_invalidScore_throwsIllegalValueException() {
-        // TODO: Replace with JsonAdaptedX
-        Map<Assessment, Score> invalidScores = new HashMap<>(VALID_SCORES);
-        invalidScores.put(new Assessment(VALID_ASSESSMENT), new Score(INVALID_SCORE));
-        JsonAdaptedStudent student =
-                new JsonAdaptedStudent(VALID_NAME, VALID_ID, VALID_GROUPS, invalidScores, VALID_TAGS);
-        assertThrows(IllegalValueException.class, student::toModelType);
+                new JsonAdaptedStudent(VALID_NAME, VALID_ID, VALID_GROUPS, invalidAssessments, VALID_TAGS);
+        Student modelStudent = student.toModelType(GROUP_LIST, ASSESSMENT_LIST);
+        assertTrue(modelStudent.getScores().keySet().stream()
+                .noneMatch(assessment -> assessment.value.equals(INVALID_ASSESSMENT)));
     }
 
     @Test
@@ -112,8 +118,8 @@ public class JsonAdaptedStudentTest {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedStudent student =
-                new JsonAdaptedStudent(VALID_NAME, VALID_ID, VALID_GROUPS, VALID_SCORES, invalidTags);
-        assertThrows(IllegalValueException.class, student::toModelType);
+                new JsonAdaptedStudent(VALID_NAME, VALID_ID, VALID_GROUPS, VALID_ASSESSMENTS, invalidTags);
+        assertThrows(IllegalValueException.class, () -> student.toModelType(GROUP_LIST, ASSESSMENT_LIST));
     }
 
 }


### PR DESCRIPTION
Closes #68 

(Also closes #66 by virtue of not needing to do anything for that)

Notable changes:
* Added GroupList and AssessmentList to the AddressBook
* Added JsonSerializableGroup and JsonSerializableAssessment
* JsonSerializableStudent does not contain information on his/her own scores
  * This is instead retrieved from the Assessment created from JsonSerializableAssessment, in order to preserve the high level of coupling and sharing of objects (particularly the score and assessment objects) between the two classes
* Some tests have been added for these, but more can be done