### PR TITLE
Add info of students added to AddGroupCommand's success message

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddGroupCommand.java
@@ -97,6 +97,9 @@ public class AddGroupCommand extends Command {
         return new CommandResult(formatSuccessMessage(addedStudents));
     }
 
+    /**
+     * Returns the formatted success message, depending on whether there were students added to the new group.
+     */
     public String formatSuccessMessage(List<Student> addedStudents) {
         String groupAddedMessage = String.format(MESSAGE_SUCCESS, toAdd.name);
 
@@ -104,11 +107,11 @@ public class AddGroupCommand extends Command {
             return groupAddedMessage;
         }
 
-        List<String> studentNames = addedStudents.stream()
+        String studentNames = addedStudents.stream()
                 .map(student -> student.getName().fullName)
-                .collect(Collectors.toList());
+                .collect(Collectors.joining(", "));
 
-        return groupAddedMessage + String.format(MESSAGE_STUDENTS_ADDED, String.join(", ", studentNames));
+        return groupAddedMessage + String.format(MESSAGE_STUDENTS_ADDED, studentNames);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddGroupCommand.java
@@ -11,6 +11,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -36,6 +37,7 @@ public class AddGroupCommand extends Command {
             + PREFIX_ID + "E0543948";
 
     public static final String MESSAGE_SUCCESS = "New group added: %1$s\n";
+    public static final String MESSAGE_STUDENTS_ADDED = "Students added to group: %1$s\n";
     public static final String MESSAGE_NONEXISTENT_STUDENT = "Student with name or ID \"%1$s\" does not exist.";
     public static final String MESSAGE_DUPLICATE_GROUP = "This group already exists in the application.";
     public static final String MESSAGE_DUPLICATE_STUDENT =
@@ -63,6 +65,8 @@ public class AddGroupCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_GROUP);
         }
 
+        List<Student> addedStudents = new ArrayList<>();
+
         for (AllocDescriptor allocDescriptor : allocDescriptors) {
             List<Student> matchedStudents = getAllocStudents(model.getAddressBook().getStudentList(), allocDescriptor);
 
@@ -85,11 +89,26 @@ public class AddGroupCommand extends Command {
 
             Student editedStudent = createEditedStudent(studentToEdit, allocDescriptor);
             toAdd.addStudent(editedStudent.getId());
+            addedStudents.add(editedStudent);
             model.setStudent(studentToEdit, editedStudent);
         }
 
         model.addGroup(toAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+        return new CommandResult(formatSuccessMessage(addedStudents));
+    }
+
+    public String formatSuccessMessage(List<Student> addedStudents) {
+        String groupAddedMessage = String.format(MESSAGE_SUCCESS, toAdd.name);
+
+        if (addedStudents.isEmpty()) {
+            return groupAddedMessage;
+        }
+
+        List<String> studentNames = addedStudents.stream()
+                .map(student -> student.getName().fullName)
+                .collect(Collectors.toList());
+
+        return groupAddedMessage + String.format(MESSAGE_STUDENTS_ADDED, String.join(", ", studentNames));
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/AddGroupCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddGroupCommandTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_GROUP_RECITATION;
@@ -10,6 +11,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.AMY;
+import static seedu.address.testutil.TypicalPersons.BOB;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.ArrayList;
@@ -82,7 +84,7 @@ public class AddGroupCommandTest {
                 new Student(AMY.getName(), AMY.getId(), newGroups, AMY.getScores(), AMY.getTags()));
 
         assertCommandSuccess(command, model,
-                String.format(AddGroupCommand.MESSAGE_SUCCESS, NEW_GROUP), expectedModel);
+                command.formatSuccessMessage(Arrays.asList(AMY)), expectedModel);
     }
 
     @Test
@@ -145,7 +147,8 @@ public class AddGroupCommandTest {
                 AMY.getName()), () -> command.execute(model));
     }
 
-    @Test void execute_ambiguousStudentName_throwsCommandException() {
+    @Test
+    public void execute_ambiguousStudentName_throwsCommandException() {
         // Two students named John Doe (with different IDs) exist in the application
         final String duplicatedName = "John Doe";
         Student firstJohn = new PersonBuilder().withName(duplicatedName).withId("E9090909").build();
@@ -162,6 +165,35 @@ public class AddGroupCommandTest {
 
         assertThrows(CommandException.class, String.format(AddGroupCommand.MESSAGE_DUPLICATE_STUDENT,
                 duplicatedName), () -> command.execute(model));
+    }
+
+    @Test
+    public void formatSuccessMessage_noStudentsToAdd_returnsGroupAddedMessage() {
+        Group standardGroup = new GroupBuilder().withName(VALID_GROUP_TUTORIAL).build();
+        AddGroupCommand standardCommand = new AddGroupCommand(standardGroup, new ArrayList<>());
+
+        // no students to add -> returns only group added message
+        assertEquals(standardCommand.formatSuccessMessage(new ArrayList<>()),
+                String.format(AddGroupCommand.MESSAGE_SUCCESS, standardGroup.name));
+    }
+
+    @Test
+    public void formatSuccessMessage_studentsToAdd_returnsGroupAndStudentsAddedMessage() {
+        Group standardGroup = new GroupBuilder().withName(VALID_GROUP_TUTORIAL).build();
+        AddGroupCommand standardCommand = new AddGroupCommand(standardGroup, new ArrayList<>());
+
+        // one student to add
+        List<Student> listWithOneStudent = Arrays.asList(AMY);
+        assertEquals(standardCommand.formatSuccessMessage(listWithOneStudent),
+                String.format(AddGroupCommand.MESSAGE_SUCCESS, standardGroup.name)
+                        + String.format(AddGroupCommand.MESSAGE_STUDENTS_ADDED, AMY.getName()));
+
+        // multiple students to add
+        List<Student> listWithMultipleStudents = Arrays.asList(AMY, BOB);
+        String names = AMY.getName().fullName + ", " + BOB.getName().fullName;
+        assertEquals(standardCommand.formatSuccessMessage(listWithMultipleStudents),
+                String.format(AddGroupCommand.MESSAGE_SUCCESS, standardGroup.name)
+                        + String.format(AddGroupCommand.MESSAGE_STUDENTS_ADDED, names));
     }
 
     @Test


### PR DESCRIPTION
Felt that it was weird that there is no feedback to the user about the students that are added when a group is added with students.

Message looks like this:
![image](https://user-images.githubusercontent.com/75519136/137244093-e07c94cc-afe3-4072-9139-3a48f5f6fc20.png)
