### PR TITLE
Add command history functionality

### DIFF
--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -1,8 +1,12 @@
 package seedu.address.ui;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -17,6 +21,11 @@ public class CommandBox extends UiPart<Region> {
     private static final String FXML = "CommandBox.fxml";
 
     private final CommandExecutor commandExecutor;
+
+    // To keep track of input history so user can switch between past inputs
+    private final List<String> pastInputs = new ArrayList<>();
+    private int inputIndex = -1;
+    private String currentInput;
 
     @FXML
     private TextField commandTextField;
@@ -44,8 +53,41 @@ public class CommandBox extends UiPart<Region> {
         try {
             commandExecutor.execute(commandText);
             commandTextField.setText("");
+            pastInputs.add(0, commandText);
         } catch (CommandException | ParseException e) {
             setStyleToIndicateCommandFailure();
+        }
+    }
+
+    /**
+     * Switches between past inputs when user keys up or down.
+     */
+    @FXML
+    private void handleUserKeystroke(KeyEvent keyEvent) {
+        if (inputIndex == -1) {
+            // save the current input so it's accessible when returning
+            currentInput = commandTextField.getText();
+        }
+
+        switch (keyEvent.getCode()) {
+        case UP:
+            if (inputIndex + 1 < pastInputs.size()) {
+                inputIndex++;
+                commandTextField.setText(pastInputs.get(inputIndex));
+                commandTextField.end();
+            }
+            break;
+        case DOWN:
+            if (inputIndex > -1) {
+                inputIndex--;
+                String newText = inputIndex == -1 ? currentInput : pastInputs.get(inputIndex);
+                commandTextField.setText(newText);
+                commandTextField.end();
+            }
+            break;
+        default:
+            // nothing special to do otherwise
+            break;
         }
     }
 

--- a/src/main/resources/view/CommandBox.fxml
+++ b/src/main/resources/view/CommandBox.fxml
@@ -4,6 +4,5 @@
 <?import javafx.scene.layout.StackPane?>
 
 <StackPane styleClass="stack-pane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-  <TextField fx:id="commandTextField" onAction="#handleCommandEntered" promptText="Enter command here..."/>
+  <TextField fx:id="commandTextField" onAction="#handleCommandEntered" onKeyPressed="#handleUserKeystroke" promptText="Enter command here..." />
 </StackPane>
-


### PR DESCRIPTION
Closes #135 

You can now press up to scroll to a previously inputted command.

Only valid commands are saved in the history.

To test: 
* Input a valid command (i.e. one that doesn't throw `ParseException` or `CommandException`)
* Input a type a few words
* Press up, it should change the input to the previous command
* Press up again, it shouldn't change the input since it's already at the oldest command
* Press down, it should return to what you were trying to type
* Press down again, it shouldn't change the input since it's already at the newest command