### PR TITLE
Handle duplicate ID and Assessment when importing from file

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -24,6 +24,7 @@ import seedu.address.model.student.ID;
 import seedu.address.model.student.Name;
 import seedu.address.model.student.Score;
 import seedu.address.model.student.Student;
+import seedu.address.model.student.exceptions.DuplicatePersonException;
 import seedu.address.model.tag.Tag;
 
 
@@ -46,6 +47,8 @@ public class ImportCommand extends Command {
     public static final String MESSAGE_INVALID_FILE = "Failed to read from the file";
     public static final String MESSAGE_INVALID_NUMBER = "Failed to read the number of columns";
     public static final String MESSAGE_OUT_OF_BOUNDS = "Reached unexpected end of line while reading from file";
+    public static final String MESSAGE_DUPLICATE_ASSESSMENT = "Duplicate assessment found in file";
+    public static final String MESSAGE_DUPLICATE_ID = "Duplicate student ID found in file";
 
     private final int groupCount;
     private final int assessmentCount;
@@ -79,12 +82,19 @@ public class ImportCommand extends Command {
         for (int i = 0; i < assessmentCount; i++) {
             String assessmentName = readValue(headers, groupCount + 2 + i);
             Assessment assessment = makeAssessment(assessmentName);
+            if (assessments.contains(assessment)) {
+                throw new CommandException(MESSAGE_DUPLICATE_ASSESSMENT);
+            }
             assessments.add(assessment);
             newAb.addAssessment(assessment);
         }
 
         for (int i = 1; i < lines.length; i++) {
-            newAb.addStudent(readStudentFromRow(lines[i], assessments, newAb.getGroupList()));
+            try {
+                newAb.addStudent(readStudentFromRow(lines[i], assessments, newAb.getGroupList()));
+            } catch (DuplicatePersonException e) {
+                throw new CommandException(MESSAGE_DUPLICATE_ID);
+            }
         }
 
         model.setAddressBook(newAb);

--- a/src/main/java/seedu/address/model/student/Group.java
+++ b/src/main/java/seedu/address/model/student/Group.java
@@ -71,7 +71,10 @@ public class Group {
      * {@code id} must not already exist in the group.
      */
     public void addStudent(ID id) {
-        students.add(id);
+        requireNonNull(id);
+        if (!hasStudent(id)) {
+            students.add(id);
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/model/student/GroupList.java
+++ b/src/main/java/seedu/address/model/student/GroupList.java
@@ -46,6 +46,7 @@ public class GroupList {
 
     /**
      * Updates the group list accordingly to the student info.
+     * Ensures that the student is properly recorded in every group in the group list
      *
      * @see seedu.address.model.AddressBook#addStudent(Student)
      */
@@ -56,6 +57,9 @@ public class GroupList {
         for (Group group : studentGroups) {
             if (!groups.contains(group)) {
                 groups.add(group);
+            } else {
+                Group groupInList = groups.get(groups.indexOf(group));
+                groupInList.addStudent(toUpdate.getId());
             }
         }
     }

--- a/src/main/java/seedu/address/model/student/Student.java
+++ b/src/main/java/seedu/address/model/student/Student.java
@@ -81,7 +81,7 @@ public class Student {
     }
 
     /**
-     * Returns true if both students have the same name.
+     * Returns true if both students have the same ID.
      * This defines a weaker notion of equality between two students.
      */
     public boolean isSameStudent(Student otherStudent) {
@@ -90,7 +90,6 @@ public class Student {
         }
 
         return otherStudent != null
-                && otherStudent.getName().equals(getName())
                 && otherStudent.getId().equals(getId());
     }
 

--- a/src/test/data/ImportCommandTest/duplicateAssessmentName.csv
+++ b/src/test/data/ImportCommandTest/duplicateAssessmentName.csv
@@ -1,0 +1,2 @@
+name,id,group1,group2,P01,P01,tag1,tag2
+Alice Pauline,E0543948,T07A,R01C,100,,friends,

--- a/src/test/data/ImportCommandTest/duplicateId.csv
+++ b/src/test/data/ImportCommandTest/duplicateId.csv
@@ -1,0 +1,3 @@
+name,id,group1,group2,P01,P02,tag1,tag2
+Alice Pauline,E0543948,T07A,R01C,100,,friends,
+Benson Meier,E0543948,T04B,R01D,100,100,owesMoney,friends

--- a/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
@@ -24,6 +24,8 @@ import seedu.address.model.tag.Tag;
 import seedu.address.testutil.TypicalPersons;
 
 public class ImportCommandTest {
+    private static final String PATH_FORMAT = "src/test/data/ImportCommandTest/%s.csv";
+
     @Test
     public void execute_validFile_success() {
         ImportCommand command = new ImportCommand(
@@ -63,13 +65,11 @@ public class ImportCommandTest {
 
     @Test
     public void execute_badData_failure() {
-        String pathFormat = "src/test/data/ImportCommandTest/%s.csv";
-
         ImportCommand command = new ImportCommand(
                 VALID_TYPICAL_PERSONS_GROUP_COUNT,
                 VALID_TYPICAL_PERSONS_ASSESSMENT_COUNT,
                 VALID_TYPICAL_PERSONS_TAG_COUNT,
-                Path.of(String.format(pathFormat, "missingAssessmentName")));
+                Path.of(String.format(PATH_FORMAT, "wrongAssessmentName")));
 
         assertCommandFailure(command, new ModelManager(), Assessment.MESSAGE_CONSTRAINTS);
 
@@ -77,15 +77,7 @@ public class ImportCommandTest {
                 VALID_TYPICAL_PERSONS_GROUP_COUNT,
                 VALID_TYPICAL_PERSONS_ASSESSMENT_COUNT,
                 VALID_TYPICAL_PERSONS_TAG_COUNT,
-                Path.of(String.format(pathFormat, "wrongAssessmentName")));
-
-        assertCommandFailure(command, new ModelManager(), Assessment.MESSAGE_CONSTRAINTS);
-
-        command = new ImportCommand(
-                VALID_TYPICAL_PERSONS_GROUP_COUNT,
-                VALID_TYPICAL_PERSONS_ASSESSMENT_COUNT,
-                VALID_TYPICAL_PERSONS_TAG_COUNT,
-                Path.of(String.format(pathFormat, "missingId")));
+                Path.of(String.format(PATH_FORMAT, "wrongId")));
 
         assertCommandFailure(command, new ModelManager(), ID.MESSAGE_CONSTRAINTS);
 
@@ -93,15 +85,7 @@ public class ImportCommandTest {
                 VALID_TYPICAL_PERSONS_GROUP_COUNT,
                 VALID_TYPICAL_PERSONS_ASSESSMENT_COUNT,
                 VALID_TYPICAL_PERSONS_TAG_COUNT,
-                Path.of(String.format(pathFormat, "wrongId")));
-
-        assertCommandFailure(command, new ModelManager(), ID.MESSAGE_CONSTRAINTS);
-
-        command = new ImportCommand(
-                VALID_TYPICAL_PERSONS_GROUP_COUNT,
-                VALID_TYPICAL_PERSONS_ASSESSMENT_COUNT,
-                VALID_TYPICAL_PERSONS_TAG_COUNT,
-                Path.of(String.format(pathFormat, "missingName")));
+                Path.of(String.format(PATH_FORMAT, "wrongName")));
 
         assertCommandFailure(command, new ModelManager(), Name.MESSAGE_CONSTRAINTS);
 
@@ -109,15 +93,7 @@ public class ImportCommandTest {
                 VALID_TYPICAL_PERSONS_GROUP_COUNT,
                 VALID_TYPICAL_PERSONS_ASSESSMENT_COUNT,
                 VALID_TYPICAL_PERSONS_TAG_COUNT,
-                Path.of(String.format(pathFormat, "wrongName")));
-
-        assertCommandFailure(command, new ModelManager(), Name.MESSAGE_CONSTRAINTS);
-
-        command = new ImportCommand(
-                VALID_TYPICAL_PERSONS_GROUP_COUNT,
-                VALID_TYPICAL_PERSONS_ASSESSMENT_COUNT,
-                VALID_TYPICAL_PERSONS_TAG_COUNT,
-                Path.of(String.format(pathFormat, "wrongGroup")));
+                Path.of(String.format(PATH_FORMAT, "wrongGroup")));
 
         assertCommandFailure(command, new ModelManager(), Group.MESSAGE_CONSTRAINTS);
 
@@ -125,7 +101,7 @@ public class ImportCommandTest {
                 VALID_TYPICAL_PERSONS_GROUP_COUNT,
                 VALID_TYPICAL_PERSONS_ASSESSMENT_COUNT,
                 VALID_TYPICAL_PERSONS_TAG_COUNT,
-                Path.of(String.format(pathFormat, "wrongScore")));
+                Path.of(String.format(PATH_FORMAT, "wrongScore")));
 
         assertCommandFailure(command, new ModelManager(), Score.MESSAGE_CONSTRAINTS);
 
@@ -133,8 +109,54 @@ public class ImportCommandTest {
                 VALID_TYPICAL_PERSONS_GROUP_COUNT,
                 VALID_TYPICAL_PERSONS_ASSESSMENT_COUNT,
                 VALID_TYPICAL_PERSONS_TAG_COUNT,
-                Path.of(String.format(pathFormat, "wrongTag")));
+                Path.of(String.format(PATH_FORMAT, "wrongTag")));
 
         assertCommandFailure(command, new ModelManager(), Tag.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void execute_missingData_failure() {
+        ImportCommand command = new ImportCommand(
+                VALID_TYPICAL_PERSONS_GROUP_COUNT,
+                VALID_TYPICAL_PERSONS_ASSESSMENT_COUNT,
+                VALID_TYPICAL_PERSONS_TAG_COUNT,
+                Path.of(String.format(PATH_FORMAT, "missingAssessmentName")));
+
+        assertCommandFailure(command, new ModelManager(), Assessment.MESSAGE_CONSTRAINTS);
+
+        command = new ImportCommand(
+                VALID_TYPICAL_PERSONS_GROUP_COUNT,
+                VALID_TYPICAL_PERSONS_ASSESSMENT_COUNT,
+                VALID_TYPICAL_PERSONS_TAG_COUNT,
+                Path.of(String.format(PATH_FORMAT, "missingId")));
+
+        assertCommandFailure(command, new ModelManager(), ID.MESSAGE_CONSTRAINTS);
+
+        command = new ImportCommand(
+                VALID_TYPICAL_PERSONS_GROUP_COUNT,
+                VALID_TYPICAL_PERSONS_ASSESSMENT_COUNT,
+                VALID_TYPICAL_PERSONS_TAG_COUNT,
+                Path.of(String.format(PATH_FORMAT, "missingName")));
+
+        assertCommandFailure(command, new ModelManager(), Name.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void execute_duplicateData_failure() {
+        ImportCommand command = new ImportCommand(
+                VALID_TYPICAL_PERSONS_GROUP_COUNT,
+                VALID_TYPICAL_PERSONS_ASSESSMENT_COUNT,
+                VALID_TYPICAL_PERSONS_TAG_COUNT,
+                Path.of(String.format(PATH_FORMAT, "duplicateAssessmentName")));
+
+        assertCommandFailure(command, new ModelManager(), ImportCommand.MESSAGE_DUPLICATE_ASSESSMENT);
+
+        command = new ImportCommand(
+                VALID_TYPICAL_PERSONS_GROUP_COUNT,
+                VALID_TYPICAL_PERSONS_ASSESSMENT_COUNT,
+                VALID_TYPICAL_PERSONS_TAG_COUNT,
+                Path.of(String.format(PATH_FORMAT, "duplicateId")));
+
+        assertCommandFailure(command, new ModelManager(), ImportCommand.MESSAGE_DUPLICATE_ID);
     }
 }

--- a/src/test/java/seedu/address/model/student/StudentTest.java
+++ b/src/test/java/seedu/address/model/student/StudentTest.java
@@ -37,27 +37,27 @@ public class StudentTest {
                 .withTags(VALID_TAG_HUSBAND).build();
         assertTrue(ALICE.isSameStudent(editedAlice));
 
-        // different name, all other attributes same -> returns false
+        // different name, all other attributes same -> returns true
         editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).build();
-        assertFalse(ALICE.isSameStudent(editedAlice));
+        assertTrue(ALICE.isSameStudent(editedAlice));
 
         // different ID, all other attributes same -> returns false
         editedAlice = new PersonBuilder(ALICE).withId(VALID_ID_BOB).build();
         assertFalse(ALICE.isSameStudent(editedAlice));
 
-        // name differs in case, all other attributes same -> returns false
+        // name differs in case, all other attributes same -> returns true
         Student editedBob = new PersonBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
-        assertFalse(BOB.isSameStudent(editedBob));
+        assertTrue(BOB.isSameStudent(editedBob));
 
         // ID differs in case, all other attributes same -> returns true
         editedBob = new PersonBuilder(BOB).withId(VALID_ID_BOB.toLowerCase()).build();
         assertEquals(editedBob.getId().value, VALID_ID_BOB);
         assertTrue(BOB.isSameStudent(editedBob));
 
-        // name has trailing spaces, all other attributes same -> returns false
+        // name has trailing spaces, all other attributes same -> returns true
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
         editedBob = new PersonBuilder(BOB).withName(nameWithTrailingSpaces).build();
-        assertFalse(BOB.isSameStudent(editedBob));
+        assertTrue(BOB.isSameStudent(editedBob));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -22,7 +22,7 @@ import seedu.address.model.util.SampleDataUtil;
 public class PersonBuilder {
 
     public static final String DEFAULT_NAME = "Amy Bee";
-    public static final String DEFAULT_ID = "E0543948";
+    public static final String DEFAULT_ID = "E0543947";
 
     private Name name;
     private ID id;


### PR DESCRIPTION
Closes #150 

Now throws CommandException when duplicate ID and Assessment are encountered.

Changed the notion of "same student" to compare only ID. There should never be two students with the same ID.
Also fixed `GroupList::update` to add the student into existing group if the group already exists.
