### PR TITLE
Fix import and export for jar file execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ src/main/resources/docs/
 /config.json
 /preferences.json
 /*.log.*
-/sourceControl*.csv
+/*sourceControl*.csv
 
 # Test sandbox files
 src/test/data/sandbox/

--- a/src/main/java/seedu/address/commons/util/FileUtil.java
+++ b/src/main/java/seedu/address/commons/util/FileUtil.java
@@ -1,6 +1,8 @@
 package seedu.address.commons.util;
 
+import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
@@ -80,4 +82,15 @@ public class FileUtil {
         Files.write(file, content.getBytes(CHARSET));
     }
 
+    /**
+     * Gets the path of the folder which the jar file is located in (or whatever is used to launch the app)
+     */
+    public static Path getAppEnclosingFolder() {
+        try {
+            return Path.of(new File(FileUtil.class.getProtectionDomain()
+                    .getCodeSource().getLocation().toURI()).getPath()).getParent();
+        } catch (URISyntaxException e) {
+            return null;
+        }
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -27,6 +27,7 @@ public class ExportCommand extends Command {
 
     public static final String BASE_PATH = "sourceControl%1$s.csv";
 
+    private final Path enclosingFolder;
     private int tries = 0;
     private int groupColumns;
     private int tagColumns;
@@ -36,6 +37,7 @@ public class ExportCommand extends Command {
      * Creates an ExportCommand to export data to a file. Ensures that a new file is created every time.
      */
     public ExportCommand() {
+        enclosingFolder = FileUtil.getAppEnclosingFolder();
         generateNewPath();
         while (FileUtil.isFileExists(file)) {
             generateNewPath();
@@ -45,7 +47,7 @@ public class ExportCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         try {
-            FileUtil.createFile(file);
+            FileUtil.createIfMissing(file);
         } catch (IOException e) {
             throw new CommandException(MESSAGE_FAILURE);
         }
@@ -143,7 +145,7 @@ public class ExportCommand extends Command {
     private void generateNewPath() {
         String path = String.format(BASE_PATH, tries == 0 ? "" : "(" + tries + ")");
         tries++;
-        this.file = Path.of(path);
+        this.file = enclosingFolder == null ? Path.of(path) : enclosingFolder.resolve(Path.of(path));
     }
 
     @Override
@@ -154,7 +156,7 @@ public class ExportCommand extends Command {
     }
 
     /**
-     * For testing to not affect any existing save data
+     * For testing to not affect any existing save data and not use the enclosing folder.
      */
     void setPath(Path path) {
         this.file = path;

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -53,7 +53,8 @@ public class ImportCommand extends Command {
     private final int groupCount;
     private final int assessmentCount;
     private final int tagCount;
-    private final Path file;
+    private final Path enclosingFolder;
+    private Path file;
 
     /**
      * Creates an ImportCommand to import data from the given {@code file}
@@ -62,7 +63,8 @@ public class ImportCommand extends Command {
         this.groupCount = groupCount;
         this.assessmentCount = assessmentCount;
         this.tagCount = tagCount;
-        this.file = file;
+        this.enclosingFolder = FileUtil.getAppEnclosingFolder();
+        this.file = generateNewPath(file);
     }
 
     @Override
@@ -195,6 +197,10 @@ public class ImportCommand extends Command {
         return new Tag(tagName);
     }
 
+    private Path generateNewPath(Path path) {
+        return enclosingFolder == null ? path : enclosingFolder.resolve(path);
+    }
+
     @Override
     public boolean equals(Object other) {
         return other == this
@@ -203,6 +209,13 @@ public class ImportCommand extends Command {
                 && this.groupCount == ((ImportCommand) other).groupCount
                 && this.assessmentCount == ((ImportCommand) other).assessmentCount
                 && this.tagCount == ((ImportCommand) other).tagCount);
+    }
+
+    /**
+     * For testing to not affect any existing save data and not use the enclosing folder.
+     */
+    void setPath(Path path) {
+        this.file = path;
     }
 }
 

--- a/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
@@ -33,6 +33,7 @@ public class ImportCommandTest {
                 VALID_TYPICAL_PERSONS_ASSESSMENT_COUNT,
                 VALID_TYPICAL_PERSONS_TAG_COUNT,
                 Path.of(VALID_TYPICAL_PERSONS_CSV_PATH));
+        command.setPath(Path.of(VALID_TYPICAL_PERSONS_CSV_PATH));
 
         Model actualModel = new ModelManager();
         Model expectedModel = new ModelManager();
@@ -48,6 +49,7 @@ public class ImportCommandTest {
                 VALID_TYPICAL_PERSONS_ASSESSMENT_COUNT,
                 VALID_TYPICAL_PERSONS_TAG_COUNT,
                 Path.of(VALID_WRONG_CSV_PATH));
+        command.setPath(Path.of(VALID_WRONG_CSV_PATH));
 
         assertCommandFailure(command, new ModelManager(), ImportCommand.MESSAGE_OUT_OF_BOUNDS);
     }
@@ -59,6 +61,7 @@ public class ImportCommandTest {
                 VALID_TYPICAL_PERSONS_ASSESSMENT_COUNT,
                 VALID_TYPICAL_PERSONS_TAG_COUNT,
                 Path.of(VALID_NON_EXISTENT_PATH));
+        command.setPath(Path.of(VALID_NON_EXISTENT_PATH));
 
         assertCommandFailure(command, new ModelManager(), ImportCommand.MESSAGE_INVALID_FILE);
     }
@@ -70,47 +73,22 @@ public class ImportCommandTest {
                 VALID_TYPICAL_PERSONS_ASSESSMENT_COUNT,
                 VALID_TYPICAL_PERSONS_TAG_COUNT,
                 Path.of(String.format(PATH_FORMAT, "wrongAssessmentName")));
-
+        command.setPath(Path.of(String.format(PATH_FORMAT, "wrongAssessmentName")));
         assertCommandFailure(command, new ModelManager(), Assessment.MESSAGE_CONSTRAINTS);
 
-        command = new ImportCommand(
-                VALID_TYPICAL_PERSONS_GROUP_COUNT,
-                VALID_TYPICAL_PERSONS_ASSESSMENT_COUNT,
-                VALID_TYPICAL_PERSONS_TAG_COUNT,
-                Path.of(String.format(PATH_FORMAT, "wrongId")));
-
+        command.setPath(Path.of(String.format(PATH_FORMAT, "wrongId")));
         assertCommandFailure(command, new ModelManager(), ID.MESSAGE_CONSTRAINTS);
 
-        command = new ImportCommand(
-                VALID_TYPICAL_PERSONS_GROUP_COUNT,
-                VALID_TYPICAL_PERSONS_ASSESSMENT_COUNT,
-                VALID_TYPICAL_PERSONS_TAG_COUNT,
-                Path.of(String.format(PATH_FORMAT, "wrongName")));
-
+        command.setPath(Path.of(String.format(PATH_FORMAT, "wrongName")));
         assertCommandFailure(command, new ModelManager(), Name.MESSAGE_CONSTRAINTS);
 
-        command = new ImportCommand(
-                VALID_TYPICAL_PERSONS_GROUP_COUNT,
-                VALID_TYPICAL_PERSONS_ASSESSMENT_COUNT,
-                VALID_TYPICAL_PERSONS_TAG_COUNT,
-                Path.of(String.format(PATH_FORMAT, "wrongGroup")));
-
+        command.setPath(Path.of(String.format(PATH_FORMAT, "wrongGroup")));
         assertCommandFailure(command, new ModelManager(), Group.MESSAGE_CONSTRAINTS);
 
-        command = new ImportCommand(
-                VALID_TYPICAL_PERSONS_GROUP_COUNT,
-                VALID_TYPICAL_PERSONS_ASSESSMENT_COUNT,
-                VALID_TYPICAL_PERSONS_TAG_COUNT,
-                Path.of(String.format(PATH_FORMAT, "wrongScore")));
-
+        command.setPath(Path.of(String.format(PATH_FORMAT, "wrongScore")));
         assertCommandFailure(command, new ModelManager(), Score.MESSAGE_CONSTRAINTS);
 
-        command = new ImportCommand(
-                VALID_TYPICAL_PERSONS_GROUP_COUNT,
-                VALID_TYPICAL_PERSONS_ASSESSMENT_COUNT,
-                VALID_TYPICAL_PERSONS_TAG_COUNT,
-                Path.of(String.format(PATH_FORMAT, "wrongTag")));
-
+        command.setPath(Path.of(String.format(PATH_FORMAT, "wrongTag")));
         assertCommandFailure(command, new ModelManager(), Tag.MESSAGE_CONSTRAINTS);
     }
 
@@ -121,23 +99,13 @@ public class ImportCommandTest {
                 VALID_TYPICAL_PERSONS_ASSESSMENT_COUNT,
                 VALID_TYPICAL_PERSONS_TAG_COUNT,
                 Path.of(String.format(PATH_FORMAT, "missingAssessmentName")));
-
+        command.setPath(Path.of(String.format(PATH_FORMAT, "missingAssessmentName")));
         assertCommandFailure(command, new ModelManager(), Assessment.MESSAGE_CONSTRAINTS);
 
-        command = new ImportCommand(
-                VALID_TYPICAL_PERSONS_GROUP_COUNT,
-                VALID_TYPICAL_PERSONS_ASSESSMENT_COUNT,
-                VALID_TYPICAL_PERSONS_TAG_COUNT,
-                Path.of(String.format(PATH_FORMAT, "missingId")));
-
+        command.setPath(Path.of(String.format(PATH_FORMAT, "missingId")));
         assertCommandFailure(command, new ModelManager(), ID.MESSAGE_CONSTRAINTS);
 
-        command = new ImportCommand(
-                VALID_TYPICAL_PERSONS_GROUP_COUNT,
-                VALID_TYPICAL_PERSONS_ASSESSMENT_COUNT,
-                VALID_TYPICAL_PERSONS_TAG_COUNT,
-                Path.of(String.format(PATH_FORMAT, "missingName")));
-
+        command.setPath(Path.of(String.format(PATH_FORMAT, "missingName")));
         assertCommandFailure(command, new ModelManager(), Name.MESSAGE_CONSTRAINTS);
     }
 
@@ -148,15 +116,10 @@ public class ImportCommandTest {
                 VALID_TYPICAL_PERSONS_ASSESSMENT_COUNT,
                 VALID_TYPICAL_PERSONS_TAG_COUNT,
                 Path.of(String.format(PATH_FORMAT, "duplicateAssessmentName")));
-
+        command.setPath(Path.of(String.format(PATH_FORMAT, "duplicateAssessmentName")));
         assertCommandFailure(command, new ModelManager(), ImportCommand.MESSAGE_DUPLICATE_ASSESSMENT);
 
-        command = new ImportCommand(
-                VALID_TYPICAL_PERSONS_GROUP_COUNT,
-                VALID_TYPICAL_PERSONS_ASSESSMENT_COUNT,
-                VALID_TYPICAL_PERSONS_TAG_COUNT,
-                Path.of(String.format(PATH_FORMAT, "duplicateId")));
-
+        command.setPath(Path.of(String.format(PATH_FORMAT, "duplicateId")));
         assertCommandFailure(command, new ModelManager(), ImportCommand.MESSAGE_DUPLICATE_ID);
     }
 }


### PR DESCRIPTION
Closes #161 

Now resolves all relative paths relative to the jar file's enclosing folder. 
If you're running windows, please do help me verify that it works on windows as well!

Just build the jar and try:
`export` (should create sourceControl.csv in the same directory as the jar file)
`export` (should create sourceControl(1).csv in the same directory as the jar file)
`import -f sourceControl.csv ...` (open the csv that was created and see how many columns to specify)
`import -f <the absolute path> ...`

All should work!