### PR TITLE
Fix data storage issue when double clicking on the jar file on MacOS

### DIFF
--- a/src/main/java/seedu/address/AppParameters.java
+++ b/src/main/java/seedu/address/AppParameters.java
@@ -1,7 +1,6 @@
 package seedu.address;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Objects;
 import java.util.logging.Logger;
@@ -38,7 +37,7 @@ public class AppParameters {
             logger.warning("Invalid config path " + configPathParameter + ". Using default config path.");
             configPathParameter = null;
         }
-        appParameters.setConfigPath(configPathParameter != null ? Paths.get(configPathParameter) : null);
+        appParameters.setConfigPath(configPathParameter != null ? FileUtil.pathOf(configPathParameter) : null);
 
         return appParameters;
     }

--- a/src/main/java/seedu/address/commons/core/Config.java
+++ b/src/main/java/seedu/address/commons/core/Config.java
@@ -1,20 +1,21 @@
 package seedu.address.commons.core;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Objects;
 import java.util.logging.Level;
+
+import seedu.address.commons.util.FileUtil;
 
 /**
  * Config values used by the app
  */
 public class Config {
 
-    public static final Path DEFAULT_CONFIG_FILE = Paths.get("config.json");
+    public static final Path DEFAULT_CONFIG_FILE = FileUtil.pathOf("config.json");
 
     // Config values customizable through config file
     private Level logLevel = Level.INFO;
-    private Path userPrefsFilePath = Paths.get("preferences.json");
+    private Path userPrefsFilePath = FileUtil.pathOf("preferences.json");
 
     public Level getLogLevel() {
         return logLevel;

--- a/src/main/java/seedu/address/commons/util/FileUtil.java
+++ b/src/main/java/seedu/address/commons/util/FileUtil.java
@@ -14,6 +14,7 @@ import java.nio.file.Paths;
 public class FileUtil {
 
     private static final String CHARSET = "UTF-8";
+    private static Path enclosingFolder;
 
     public static boolean isFileExists(Path file) {
         return Files.exists(file) && Files.isRegularFile(file);
@@ -85,12 +86,32 @@ public class FileUtil {
     /**
      * Gets the path of the folder which the jar file is located in (or whatever is used to launch the app)
      */
-    public static Path getAppEnclosingFolder() {
+    private static Path getAppEnclosingFolder() {
         try {
-            return Path.of(new File(FileUtil.class.getProtectionDomain()
-                    .getCodeSource().getLocation().toURI()).getPath()).getParent();
+            if (enclosingFolder == null) {
+                enclosingFolder = Path.of(new File(FileUtil.class.getProtectionDomain()
+                        .getCodeSource().getLocation().toURI()).getPath()).getParent();
+            }
+            return enclosingFolder;
         } catch (URISyntaxException e) {
             return null;
         }
+    }
+
+    /**
+     * Gets the absolute path, relative to where the jar file is located.
+     */
+    public static Path pathOf(String first, String... more) {
+        Path path = Path.of(first, more);
+        return getAppEnclosingFolder() == null ? path : enclosingFolder.resolve(path);
+    }
+
+    /**
+     * Gets the path, relative to where the jar file is located.
+     */
+    public static Path getRelativePath(Path path) {
+        return getAppEnclosingFolder() == null
+                ? path
+                : Path.of(".").resolve(getAppEnclosingFolder().relativize(path));
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -191,7 +191,6 @@ public class ParserUtil {
         if (!path.endsWith(extension)) {
             path = path + extension;
         }
-        Path enclosingFolder = FileUtil.getAppEnclosingFolder();
-        return enclosingFolder == null ? Path.of(path) : enclosingFolder.resolve(Path.of(path));
+        return FileUtil.pathOf(path);
     }
 }

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -3,12 +3,12 @@ package seedu.address.model;
 import static java.util.Objects.requireNonNull;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.commons.util.FileUtil;
 import seedu.address.logic.parser.Alias;
 
 /**
@@ -17,7 +17,7 @@ import seedu.address.logic.parser.Alias;
 public class UserPrefs implements ReadOnlyUserPrefs {
 
     private GuiSettings guiSettings = new GuiSettings();
-    private Path addressBookFilePath = Paths.get("data" , "sourcecontrol.json");
+    private Path addressBookFilePath = FileUtil.pathOf("data" , "sourcecontrol.json");
     private Map<String, String> aliases = new HashMap<>();
 
     /**

--- a/src/main/java/seedu/address/ui/StatusBarFooter.java
+++ b/src/main/java/seedu/address/ui/StatusBarFooter.java
@@ -1,11 +1,11 @@
 package seedu.address.ui;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Region;
+import seedu.address.commons.util.FileUtil;
 
 /**
  * A ui for the status bar that is displayed at the footer of the application.
@@ -22,7 +22,7 @@ public class StatusBarFooter extends UiPart<Region> {
      */
     public StatusBarFooter(Path saveLocation) {
         super(FXML);
-        saveLocationStatus.setText(Paths.get(".").resolve(saveLocation).toString());
+        saveLocationStatus.setText(FileUtil.getRelativePath(saveLocation).toString());
     }
 
 }

--- a/src/test/java/seedu/address/AppParametersTest.java
+++ b/src/test/java/seedu/address/AppParametersTest.java
@@ -2,7 +2,6 @@ package seedu.address;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -11,6 +10,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 import javafx.application.Application;
+import seedu.address.commons.util.FileUtil;
 
 public class AppParametersTest {
 
@@ -20,7 +20,7 @@ public class AppParametersTest {
     @Test
     public void parse_validConfigPath_success() {
         parametersStub.namedParameters.put("config", "config.json");
-        expected.setConfigPath(Paths.get("config.json"));
+        expected.setConfigPath(FileUtil.pathOf("config.json"));
         assertEquals(expected, AppParameters.parse(parametersStub));
     }
 

--- a/src/test/java/seedu/address/commons/core/ConfigTest.java
+++ b/src/test/java/seedu/address/commons/core/ConfigTest.java
@@ -6,12 +6,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.util.FileUtil;
+
 public class ConfigTest {
 
     @Test
     public void toString_defaultObject_stringReturned() {
         String defaultConfigAsString = "Current log level : INFO\n"
-                + "Preference file Location : preferences.json";
+                + "Preference file Location : "
+                + FileUtil.pathOf("preferences.json");
 
         assertEquals(defaultConfigAsString, new Config().toString());
     }


### PR DESCRIPTION
It's fine if you leave this til 1.4 to merge, but it would be better if we had the free bug testing from tomorrow.

Ensure the following work (especially if you are on Windows):

1. Data persists between runs
1. Export command works with an absolute path specified
1. Export command works with a relative path specified
1. Export command works without the -f flag
1. Show command works with a -f flag
1. Import command works
1. Data is stored at expected locations (same locations as before this change)