### PR TITLE
Use shared instances for Assessments and Groups in SampleDataUtil

### DIFF
--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
@@ -26,13 +27,7 @@ import seedu.address.model.tag.Tag;
 public class SampleDataUtil {
     private static final Random random = new Random();
 
-    /**
-     * For sample data, the maximum group number and group suffix is kept sufficiently small so that each group can
-     * have a reasonable number of students in it.
-     */
-    private static final int MAX_GROUP_NUMBER = 3;
-    private static final char MAX_GROUP_SUFFIX = 'C';
-
+    //// Configuration variables
     private static final String[] SAMPLE_STUDENT_NAMES = {
         "How Kai Xin", "Wu Wei Le", "Ruchi Rattan", "Eva Porter", "Lai Guo Qiang Jack", "Tang Jia Xin",
         "Damini Kashyap", "Zhuang Yi Xi", "Winnie Ong Jia Ling", "Irfan Syahid Bin Mohammad Aydin", "Chen Kok Meng",
@@ -44,15 +39,20 @@ public class SampleDataUtil {
         "David Balasubramanian", "Tin Zhi Xin", "Asher Edwards", "Baey Yi De", "Low Hui Qi", "Chang Hao Ming",
         "Jackson Adams", "Edward Davidson", "Sim Hui Qi", "Kanika Kothari", "Tang Xin En", "Tin Zhi En"
     };
-
+    // Max group number and suffix is kept sufficiently small so that each group has a reasonable number of students
+    private static final int MAX_GROUP_NUMBER = 3;
+    private static final char NUMBER_OF_SUFFIXES = 3;
+    private static final String[] SAMPLE_TAG_NAMES = {"beginner", "intermediate", "advanced"};
     private static final String[] SAMPLE_ASSESSMENT_NAMES = {
         "Reading Assessment 1", "Reading Assessment 2", "Midterm Examination", "Practical Assessment",
         "Final Examination"
     };
 
-    private static final String[] SAMPLE_TAG_NAMES = {
-        "beginner", "intermediate", "advanced"
-    };
+    //// Shared instances
+    private static final List<Group> SAMPLE_TUTORIAL_GROUPS = getRandomGroups("T");
+    private static final List<Group> SAMPLE_RECITATION_GROUPS = getRandomGroups("R");
+    private static final List<Assessment> SAMPLE_ASSESSMENTS = Arrays.stream(SAMPLE_ASSESSMENT_NAMES)
+            .map(Assessment::new).collect(Collectors.toList());
 
     /**
      * Stores the IDs that have been randomly generated and created, to avoid generating duplicate IDs.
@@ -63,8 +63,12 @@ public class SampleDataUtil {
         List<Student> sampleStudents = new ArrayList<>();
 
         for (String studentName : SAMPLE_STUDENT_NAMES) {
-            Student student = new Student(new Name(studentName), getRandomStudentId(),
-                    getGroupList(getRandomTutorialGroup(), getRandomRecitationGroup()),
+            ID studentId = getRandomStudentId();
+            List<Group> groups = Arrays.asList(getRandomTutorialGroup(), getRandomRecitationGroup());
+            for (Group group : groups) {
+                group.addStudent(studentId);
+            }
+            Student student = new Student(new Name(studentName), studentId, groups,
                     getRandomAssessmentScores(), getTagSet(getRandomTag()));
             sampleStudents.add(student);
         }
@@ -97,33 +101,37 @@ public class SampleDataUtil {
         return new ID(studentId);
     }
 
-    /**
-     * Generates a random name of a tutorial group, which begins with 'T'.
-     */
-    public static String getRandomTutorialGroup() {
-        return "T" + getRandomGroupNumber() + getRandomGroupSuffix();
+    public static List<Group> getRandomGroups(String prefix) {
+        assert MAX_GROUP_NUMBER >= 1;
+        List<Integer> groupNumbers = IntStream.rangeClosed(1, MAX_GROUP_NUMBER).boxed().collect(Collectors.toList());
+
+        assert NUMBER_OF_SUFFIXES >= 1;
+        List<Character> suffixes = IntStream.range(0, NUMBER_OF_SUFFIXES).boxed()
+                .map(num -> (char) ('A' + num)).collect(Collectors.toList());
+
+        List<Group> groups = new ArrayList<>();
+        for (Integer groupNumber : groupNumbers) {
+            for (Character suffix : suffixes) {
+                String groupName = prefix + String.format("%02d", groupNumber) + suffix;
+                groups.add(new Group(groupName));
+            }
+        }
+
+        return groups;
     }
 
     /**
-     * Generates a random name of a recitation group, which begins with 'R'.
+     * Returns a random group from the list of generated sample tutorial groups.
      */
-    public static String getRandomRecitationGroup() {
-        return "R" + getRandomGroupNumber() + getRandomGroupSuffix();
+    public static Group getRandomTutorialGroup() {
+        return SAMPLE_TUTORIAL_GROUPS.get(random.nextInt(SAMPLE_TUTORIAL_GROUPS.size()));
     }
 
     /**
-     * Generates a random group number.
+     * Returns a random group from the list of generated sample recitation groups.
      */
-    public static String getRandomGroupNumber() {
-        int randomGroupNumber = random.nextInt(MAX_GROUP_NUMBER) + 1;
-        return String.format("%02d", randomGroupNumber);
-    }
-
-    /**
-     * Generates a random group suffix.
-     */
-    public static char getRandomGroupSuffix() {
-        return (char) ('A' + random.nextInt(MAX_GROUP_SUFFIX - 'A'));
+    public static Group getRandomRecitationGroup() {
+        return SAMPLE_RECITATION_GROUPS.get(random.nextInt(SAMPLE_RECITATION_GROUPS.size()));
     }
 
     /**
@@ -132,9 +140,9 @@ public class SampleDataUtil {
     public static Map<Assessment, Score> getRandomAssessmentScores() {
         Map<Assessment, Score> scores = new LinkedHashMap<>();
 
-        for (String assessmentName : SAMPLE_ASSESSMENT_NAMES) {
+        for (Assessment assessment : SAMPLE_ASSESSMENTS) {
             String s = String.format("%.2f", getRandomScore());
-            scores.put(new Assessment(assessmentName), new Score(s));
+            scores.put(assessment, new Score(s));
         }
 
         return scores;


### PR DESCRIPTION
Fixes #225 

Changes
- SampleDataUtil now uses shared instances of Assessments and Groups, instead of creating a new one for each student

How to test
- Run `gradlew clean build` 
- Run the jar file 
- Run command `show -i <student_id>` and verify that the graph correctly plots the assessment stats
- Run command `show -g <group_name>` and verify that the group contains all the students who are in the group (based on the Ui). Or run `show -g <group_name>` for all groups then verify that the total number of students sum up to 50.