### PR TITLE
v1.4 - line chart wrap axis names

### DIFF
--- a/src/main/java/seedu/address/commons/util/ChartUtil.java
+++ b/src/main/java/seedu/address/commons/util/ChartUtil.java
@@ -1,5 +1,6 @@
 package seedu.address.commons.util;
 
+import java.util.ArrayList;
 import java.util.Map;
 
 import javafx.scene.chart.BarChart;
@@ -78,19 +79,19 @@ public class ChartUtil {
         XYChart.Series seriesScore = new XYChart.Series();
         seriesScore.setName(dataLabel);
         for (Map.Entry<String, Number> entry : data.entrySet()) {
-            seriesScore.getData().add(new XYChart.Data(entry.getKey(), entry.getValue()));
+            seriesScore.getData().add(new XYChart.Data(wrap(entry.getKey()), entry.getValue()));
         }
 
         XYChart.Series seriesMean = new XYChart.Series();
         seriesMean.setName("cohort mean");
         for (Map.Entry<String, Number> entry : mean.entrySet()) {
-            seriesMean.getData().add(new XYChart.Data(entry.getKey(), entry.getValue()));
+            seriesMean.getData().add(new XYChart.Data(wrap(entry.getKey()), entry.getValue()));
         }
 
         XYChart.Series seriesMedian = new XYChart.Series();
         seriesMedian.setName("cohort median");
         for (Map.Entry<String, Number> entry : median.entrySet()) {
-            seriesMedian.getData().add(new XYChart.Data(entry.getKey(), entry.getValue()));
+            seriesMedian.getData().add(new XYChart.Data(wrap(entry.getKey()), entry.getValue()));
         }
 
         lineChart.getData().addAll(seriesScore, seriesMean, seriesMedian);
@@ -98,7 +99,84 @@ public class ChartUtil {
         return lineChart;
     }
 
-    private static double roundUpToNearestMultiple(double val, int multiple) {
+    public static double roundUpToNearestMultiple(double val, int multiple) {
         return Math.round(val / multiple) * multiple;
+    }
+
+    public static String wrap(String string) {
+        String[] words = string.split(" ");
+        int count = 0;
+        ArrayList<String> result = new ArrayList<>();
+        int line = 0;
+
+        while (count < words.length) {
+            // check if exceed line limit
+            if (line == 3) {
+                break;
+            }
+
+            int currLineLength = 0;
+            if (result.size() - 1 == line) {
+                currLineLength = result.get(line).length();
+            }
+            int wordLength = words[count].length();
+
+            // if nothing in current line, and next word can fit
+            if (currLineLength == 0 && wordLength <= 12) {
+                result.add(words[count]);
+                count++;
+                continue;
+            }
+
+            // word can fit into previous line
+            if (wordLength + currLineLength + 1 <= 12) {
+                result.set(line, result.get(line) + " " + words[count]);
+                count++;
+                continue;
+            }
+
+            // word cannot fit into previous line, but word is below size limit
+            if (wordLength <= 12) {
+                line++;
+                result.add(words[count]);
+                count++;
+                continue;
+            }
+
+            // if nothing in curr line, but next word cannot fit
+            if (currLineLength == 0) {
+                result.add(words[count].substring(0, 12));
+                words[count] = words[count].substring(12);
+                line++;
+                continue;
+            }
+
+            // if something in current line, fill up current line first
+            int temp = 12 - 1 - currLineLength;
+            if (temp < 0) {
+                line++;
+                continue;
+            }
+            result.set(line, result.get(line) + " " + words[count].substring(0, temp));
+            words[count] = words[count].substring(temp);
+            line++;
+        }
+
+        int numOfLines = result.size() - 1;
+
+        String wrappedString = result.get(0);
+
+        if (count < words.length) {
+            result.set(2, result.get(2).substring(0, 10) + "...");
+        }
+        if (numOfLines >= 1) {
+            wrappedString += "\n" + result.get(1);
+        }
+        if (numOfLines >= 2) {
+            wrappedString += "\n" + result.get(2);
+        }
+
+        return wrappedString;
+
     }
 }

--- a/src/main/java/seedu/address/commons/util/ChartUtil.java
+++ b/src/main/java/seedu/address/commons/util/ChartUtil.java
@@ -99,10 +99,17 @@ public class ChartUtil {
         return lineChart;
     }
 
+    /**
+     * Rounds up {@code double val} to multiples of {@code int multiple}.
+     */
     public static double roundUpToNearestMultiple(double val, int multiple) {
         return Math.round(val / multiple) * multiple;
     }
 
+
+    /**
+     * Wraps the given string such that each line contains maximum of 12 characters, with a maximum of 3 lines.
+     */
     public static String wrap(String string) {
         String[] words = string.split(" ");
         int count = 0;

--- a/src/main/java/seedu/address/commons/util/ChartUtil.java
+++ b/src/main/java/seedu/address/commons/util/ChartUtil.java
@@ -143,7 +143,7 @@ public class ChartUtil {
             }
 
             // word cannot fit into previous line, but word is below size limit
-            if (wordLength <= 12) {
+            if (wordLength <= 12 && line < 2) {
                 line++;
                 result.add(words[count]);
                 count++;

--- a/src/test/java/seedu/address/commons/util/ChartUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/ChartUtilTest.java
@@ -26,6 +26,8 @@ public class ChartUtilTest {
         assertEquals(ChartUtil.wrap("aspecialcase longwordcannotfit"), "aspecialcase\nlongwordcann\notfit");
         assertEquals(ChartUtil.wrap("short short short short short short short short short"),
                 "short short\n" + "short short\n" + "short shor...");
+        assertEquals(ChartUtil.wrap("super long long long long long assessment"),
+                "super long\n" + "long long\n" + "long long ...");
         assertEquals(ChartUtil.wrap("short longwordcannotfit short longwordcannotfit"),
                 "short longwo\n" + "rdcannotfit\n" + "short long...");
         assertEquals(ChartUtil.wrap("superlongonewordsuperlongonewordsuperlongoneword"),

--- a/src/test/java/seedu/address/commons/util/ChartUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/ChartUtilTest.java
@@ -1,11 +1,8 @@
 package seedu.address.commons.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
-import seedu.address.model.student.*;
 
 public class ChartUtilTest {
 
@@ -28,7 +25,7 @@ public class ChartUtilTest {
         assertEquals(ChartUtil.wrap("short longwordcannotfit"), "short longwo\nrdcannotfit");
         assertEquals(ChartUtil.wrap("aspecialcase longwordcannotfit"), "aspecialcase\nlongwordcann\notfit");
         assertEquals(ChartUtil.wrap("short short short short short short short short short"),
-        "short short\n" + "short short\n" + "short shor...");
+                "short short\n" + "short short\n" + "short shor...");
         assertEquals(ChartUtil.wrap("short longwordcannotfit short longwordcannotfit"),
                 "short longwo\n" + "rdcannotfit\n" + "short long...");
         assertEquals(ChartUtil.wrap("superlongonewordsuperlongonewordsuperlongoneword"),

--- a/src/test/java/seedu/address/commons/util/ChartUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/ChartUtilTest.java
@@ -1,0 +1,37 @@
+package seedu.address.commons.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.model.student.*;
+
+public class ChartUtilTest {
+
+    @Test
+    public void roundUpToNearestMultiple() {
+        assertEquals(ChartUtil.roundUpToNearestMultiple(12.55, 5), 15);
+        assertEquals(ChartUtil.roundUpToNearestMultiple(14.5, 5), 15);
+        assertEquals(ChartUtil.roundUpToNearestMultiple(5.0, 5), 5);
+        assertEquals(ChartUtil.roundUpToNearestMultiple(2.45, 5), 0);
+        assertEquals(ChartUtil.roundUpToNearestMultiple(19.9, 5), 20);
+    }
+
+    @Test
+    public void wrap() {
+        assertEquals(ChartUtil.wrap(""), "");
+        assertEquals(ChartUtil.wrap("short"), "short");
+        assertEquals(ChartUtil.wrap("short word"), "short word");
+        assertEquals(ChartUtil.wrap("short longword"), "short\nlongword");
+        assertEquals(ChartUtil.wrap("longwordcannotfit"), "longwordcann\notfit");
+        assertEquals(ChartUtil.wrap("short longwordcannotfit"), "short longwo\nrdcannotfit");
+        assertEquals(ChartUtil.wrap("aspecialcase longwordcannotfit"), "aspecialcase\nlongwordcann\notfit");
+        assertEquals(ChartUtil.wrap("short short short short short short short short short"),
+        "short short\n" + "short short\n" + "short shor...");
+        assertEquals(ChartUtil.wrap("short longwordcannotfit short longwordcannotfit"),
+                "short longwo\n" + "rdcannotfit\n" + "short long...");
+        assertEquals(ChartUtil.wrap("superlongonewordsuperlongonewordsuperlongoneword"),
+                "superlongone\n" + "wordsuperlon\n" + "gonewordsu...");
+    }
+}


### PR DESCRIPTION
wrap long axis names: 
- each line max 12 characters
- max 3 lines
- if exceed 3 line end string with `...`
- tries to wrap by words first, if the word cannot fit into one line(>12 characters), then break the word into two or more lines. 

can take a look at test cases first to see how it works
