### PR TITLE
Ensure that students are changed only if add group is successful

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddGroupCommand.java
@@ -45,7 +45,8 @@ public class AddGroupCommand extends Command {
     public static final String MESSAGE_DUPLICATE_GROUP = "This group already exists in the application.";
     public static final String MESSAGE_DUPLICATE_STUDENT =
             "The student \"%1$s\" needs to be allocated manually using ID due to duplicate naming.";
-    public static final String MESSAGE_DUPLICATE_STUDENT_IN_GROUP = "The student \"%1$s\" already exists in the group.";
+    public static final String MESSAGE_DUPLICATE_STUDENT_IN_GROUP =
+            "The student \"%1$s\" (%2$s) was specified more than once.";
 
     private final Group groupToAdd;
     private final List<AllocDescriptor> allocDescriptors;
@@ -93,7 +94,8 @@ public class AddGroupCommand extends Command {
             }
 
             if (groupToAdd.hasStudent(studentToEdit.getId())) {
-                throw new CommandException(String.format(MESSAGE_DUPLICATE_STUDENT_IN_GROUP, studentToEdit.getName()));
+                throw new CommandException(String.format(MESSAGE_DUPLICATE_STUDENT_IN_GROUP,
+                        studentToEdit.getName(), studentToEdit.getId()));
             }
 
             originalStudents.add(studentToEdit);

--- a/src/main/java/seedu/address/logic/commands/AddGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddGroupCommand.java
@@ -47,7 +47,7 @@ public class AddGroupCommand extends Command {
             "The student \"%1$s\" needs to be allocated manually using ID due to duplicate naming.";
     public static final String MESSAGE_DUPLICATE_STUDENT_IN_GROUP = "The student \"%1$s\" already exists in the group.";
 
-    private final Group toAdd;
+    private final Group groupToAdd;
     private final List<AllocDescriptor> allocDescriptors;
 
     /**
@@ -56,7 +56,7 @@ public class AddGroupCommand extends Command {
     public AddGroupCommand(Group group, List<AllocDescriptor> allocDescriptors) {
         requireNonNull(group);
         requireNonNull(allocDescriptors);
-        toAdd = group;
+        groupToAdd = group;
         this.allocDescriptors = new ArrayList<>(allocDescriptors);
     }
 
@@ -64,10 +64,11 @@ public class AddGroupCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        if (model.hasGroup(toAdd)) {
+        if (model.hasGroup(groupToAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_GROUP);
         }
 
+        List<Student> originalStudents = new ArrayList<>();
         List<Student> addedStudents = new ArrayList<>();
 
         for (AllocDescriptor allocDescriptor : allocDescriptors) {
@@ -91,17 +92,23 @@ public class AddGroupCommand extends Command {
                 throw new CommandException(String.format(MESSAGE_DUPLICATE_STUDENT, studentToEdit.getName()));
             }
 
-            if (toAdd.hasStudent(studentToEdit.getId())) {
+            if (groupToAdd.hasStudent(studentToEdit.getId())) {
                 throw new CommandException(String.format(MESSAGE_DUPLICATE_STUDENT_IN_GROUP, studentToEdit.getName()));
             }
 
+            originalStudents.add(studentToEdit);
             Student editedStudent = createEditedStudent(studentToEdit, allocDescriptor);
-            toAdd.addStudent(editedStudent.getId());
+            groupToAdd.addStudent(editedStudent.getId());
             addedStudents.add(editedStudent);
-            model.setStudent(studentToEdit, editedStudent);
         }
 
-        model.addGroup(toAdd);
+        model.addGroup(groupToAdd);
+
+        assert originalStudents.size() == addedStudents.size();
+        for (int i = 0; i < originalStudents.size(); i++) {
+            model.setStudent(originalStudents.get(i), addedStudents.get(i));
+        }
+
         return new CommandResult(formatSuccessMessage(addedStudents));
     }
 
@@ -109,7 +116,7 @@ public class AddGroupCommand extends Command {
      * Returns the formatted success message, depending on whether there were students added to the new group.
      */
     public String formatSuccessMessage(List<Student> addedStudents) {
-        String groupAddedMessage = String.format(MESSAGE_SUCCESS, toAdd.name);
+        String groupAddedMessage = String.format(MESSAGE_SUCCESS, groupToAdd.name);
 
         if (addedStudents.isEmpty()) {
             return groupAddedMessage;
@@ -137,7 +144,7 @@ public class AddGroupCommand extends Command {
         // state check
         AddGroupCommand e = (AddGroupCommand) other;
 
-        return toAdd.equals(e.toAdd)
+        return groupToAdd.equals(e.groupToAdd)
                 && equalsIgnoreOrder(allocDescriptors, e.allocDescriptors);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/AddGroupCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddGroupCommandTest.java
@@ -144,7 +144,7 @@ public class AddGroupCommandTest {
         AddGroupCommand command = new AddGroupCommand(groupToAdd, Arrays.asList(amyNameDescriptor, amyIdDescriptor));
 
         assertThrows(CommandException.class, String.format(AddGroupCommand.MESSAGE_DUPLICATE_STUDENT_IN_GROUP,
-                AMY.getName()), () -> command.execute(model));
+                AMY.getName(), AMY.getId()), () -> command.execute(model));
     }
 
     @Test


### PR DESCRIPTION
Fixes #215 
Fixes #199 

To test
1. open app with sample data
2. execute command `addgroup -g TestGroup1 -n Ruchi Rattan -n Ruchi Rattan` and see that the group is not added to Ruchi Rattan.