### PR TITLE
Fix duplicated groups being added via addstudent command

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -10,6 +10,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddCommand;
@@ -45,6 +46,9 @@ public class AddCommandParser implements Parser<AddCommand> {
         ID id = ParserUtil.parseID(argMultimap.getValue(PREFIX_ID).get());
 
         List<Group> groupList = ParserUtil.parseGroups(argMultimap.getAllValues(PREFIX_GROUP));
+        groupList = (groupList != null)
+                ? groupList.stream().distinct().collect(Collectors.toList())
+                : null;
         Map<Assessment, Score> emptyScores = new LinkedHashMap<>();
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -68,6 +68,16 @@ public class AddCommandParserTest {
         assertParseSuccess(parser, NAME_DESC_BOB + ID_DESC_BOB + GROUP_DESC_TUTORIAL + GROUP_DESC_RECITATION
                 + TAG_DESC_FRIEND, new AddCommand(expectedStudentMultipleGroups));
 
+        //multiple similar groups - only one unique instance accepted
+        Student expectedStudentWithMultipleSimilarGroups = new PersonBuilder(BOB)
+                .withScores(new LinkedHashMap<>())
+                .withGroups(VALID_GROUP_RECITATION)
+                .withTags(VALID_TAG_FRIEND)
+                .build();
+        assertParseSuccess(parser, NAME_DESC_BOB + ID_DESC_BOB + GROUP_DESC_RECITATION
+                + GROUP_DESC_RECITATION + TAG_DESC_FRIEND,
+                new AddCommand(expectedStudentWithMultipleSimilarGroups));
+
         // multiple tags - all accepted
         Student expectedStudentMultipleTags = new PersonBuilder(BOB)
                 .withScores(new LinkedHashMap<>())


### PR DESCRIPTION
closes #245 
- Test using `addstudent -n john -i e1111111 -g R01A -g R01A`
- Added a test for this duplicate group behaviour too