### PR TITLE
Chart UI enhancements

### DIFF
--- a/src/main/java/seedu/address/commons/util/ChartUtil.java
+++ b/src/main/java/seedu/address/commons/util/ChartUtil.java
@@ -90,26 +90,29 @@ public class ChartUtil {
         lineChart.setTitle(title);
         lineChart.setId("chart1");
 
-        // Input data points: score, mean, median
-        XYChart.Series seriesScore = new XYChart.Series();
+        // Input score data points
+        XYChart.Series<String, Number> seriesScore = new XYChart.Series<>();
         seriesScore.setName(dataLabel);
         for (Map.Entry<String, Number> entry : data.entrySet()) {
-            seriesScore.getData().add(new XYChart.Data(wrap(entry.getKey()), entry.getValue()));
+            seriesScore.getData().add(new XYChart.Data<>(wrap(entry.getKey()), entry.getValue()));
         }
+        lineChart.getData().add(seriesScore);
 
-        XYChart.Series seriesMean = new XYChart.Series();
+        // Input mean data points
+        XYChart.Series<String, Number> seriesMean = new XYChart.Series<>();
         seriesMean.setName("cohort mean");
         for (Map.Entry<String, Number> entry : mean.entrySet()) {
-            seriesMean.getData().add(new XYChart.Data(wrap(entry.getKey()), entry.getValue()));
+            seriesMean.getData().add(new XYChart.Data<>(wrap(entry.getKey()), entry.getValue()));
         }
+        lineChart.getData().add(seriesMean);
 
-        XYChart.Series seriesMedian = new XYChart.Series();
+        // Input median data points
+        XYChart.Series<String, Number> seriesMedian = new XYChart.Series<>();
         seriesMedian.setName("cohort median");
         for (Map.Entry<String, Number> entry : median.entrySet()) {
-            seriesMedian.getData().add(new XYChart.Data(wrap(entry.getKey()), entry.getValue()));
+            seriesMedian.getData().add(new XYChart.Data<>(wrap(entry.getKey()), entry.getValue()));
         }
-
-        lineChart.getData().addAll(seriesScore, seriesMean, seriesMedian);
+        lineChart.getData().add(seriesMedian);
 
         return lineChart;
     }
@@ -120,7 +123,6 @@ public class ChartUtil {
     public static double roundUpToNearestMultiple(double val, int multiple) {
         return Math.round(val / multiple) * multiple;
     }
-
 
     /**
      * Wraps the given string such that each line contains maximum of 12 characters, with a maximum of 3 lines.

--- a/src/main/java/seedu/address/commons/util/ChartUtil.java
+++ b/src/main/java/seedu/address/commons/util/ChartUtil.java
@@ -8,12 +8,26 @@ import javafx.scene.chart.CategoryAxis;
 import javafx.scene.chart.LineChart;
 import javafx.scene.chart.NumberAxis;
 import javafx.scene.chart.XYChart;
+import javafx.util.StringConverter;
+import seedu.address.model.student.Score;
 
 /**
  * Creates JavaFX charts
  */
 public class ChartUtil {
     private static final double DEFAULT_TICK_UNIT = 5.0;
+    private static final StringConverter<Number> CUSTOM_TICK_LABEL_FORMATTER = new StringConverter<>() {
+        @Override
+        public String toString(Number number) {
+            // Hide labels that are greater than max score since they only serve as padding
+            return number.doubleValue() > Score.MAX_SCORE ? "" : String.valueOf(number.intValue());
+        }
+
+        @Override
+        public Number fromString(String string) {
+            return Double.parseDouble(string);
+        }
+    };
 
     /**
      * Creates a JavaFX BarChart with the given title, axis labels and data points.
@@ -70,6 +84,7 @@ public class ChartUtil {
         yAxis.setLowerBound(0);
         yAxis.setUpperBound(104);
         yAxis.setTickUnit(10);
+        yAxis.setTickLabelFormatter(CUSTOM_TICK_LABEL_FORMATTER);
 
         final LineChart<String, Number> lineChart = new LineChart<String, Number>(xAxis, yAxis);
         lineChart.setTitle(title);

--- a/src/main/java/seedu/address/logic/commands/ShowCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ShowCommand.java
@@ -207,7 +207,7 @@ public class ShowCommand extends Command {
         model.updateFilteredStudentList(predicate);
 
         Info info = new Info(matchedGroup);
-        GroupStatistics statistics = new GroupStatistics(matchedGroup, model);
+        GroupStatistics statistics = new GroupStatistics(matchedGroup, model.getAddressBook().getAssessmentList());
         return new CommandResult(MESSAGE_SUCCESS, info, statistics.toLineChart(), savePath);
     }
 

--- a/src/main/java/seedu/address/model/student/GroupStatistics.java
+++ b/src/main/java/seedu/address/model/student/GroupStatistics.java
@@ -3,14 +3,13 @@ package seedu.address.model.student;
 import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import javafx.scene.chart.Chart;
 import seedu.address.commons.util.ChartUtil;
-import seedu.address.model.Model;
 
 /**
  * Represents statistics about a student and the students' performance in each assessment.
@@ -21,7 +20,6 @@ public class GroupStatistics {
     private static final String CHART_X_AXIS_LABEL = "Assessments";
     private static final String CHART_Y_AXIS_LABEL = "Scores";
 
-    private final Model model;
     private final Group group;
     private final List<ID> studentList;
     private final List<Assessment> assessmentList;
@@ -29,14 +27,13 @@ public class GroupStatistics {
     /**
      * Constructs a {@code GroupStatistics} with the specified {@code group}.
      */
-    public GroupStatistics(Group group, Model model) {
-        requireNonNull(model);
+    public GroupStatistics(Group group, List<Assessment> assessmentList) {
         requireNonNull(group);
         requireNonNull(group.getStudents());
-        this.model = model;
+        requireNonNull(assessmentList);
         this.group = group;
         this.studentList = group.getStudents();
-        this.assessmentList = model.getAddressBook().getAssessmentList();
+        this.assessmentList = assessmentList;
     }
 
     /**
@@ -90,9 +87,9 @@ public class GroupStatistics {
      * and the third element contains the cohort median distribution.
      */
     private Map<String, Number>[] getDataSet() {
-        Map<String, Number> cohortMean = new TreeMap<>();
-        Map<String, Number> groupMedian = new TreeMap<>();
-        Map<String, Number> cohortMedian = new TreeMap<>();
+        Map<String, Number> groupMedian = new LinkedHashMap<>();
+        Map<String, Number> cohortMean = new LinkedHashMap<>();
+        Map<String, Number> cohortMedian = new LinkedHashMap<>();
 
         for (Assessment assessment: assessmentList) {
             if (!isGraded(assessment)) {

--- a/src/main/java/seedu/address/model/student/StudentStatistics.java
+++ b/src/main/java/seedu/address/model/student/StudentStatistics.java
@@ -2,8 +2,8 @@ package seedu.address.model.student;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.TreeMap;
 
 import javafx.scene.chart.Chart;
 import seedu.address.commons.util.ChartUtil;
@@ -34,7 +34,7 @@ public class StudentStatistics {
      * Returns a distribution of student's scores for the assessment.
      */
     public Map<String, Number> getScoreDistribution() {
-        Map<String, Number> distribution = new TreeMap<>();
+        Map<String, Number> distribution = new LinkedHashMap<>();
         scoreMap.forEach((assessment, score) -> distribution.put(assessment.getName(), score.getNumericValue()));
         return distribution;
     }
@@ -46,8 +46,8 @@ public class StudentStatistics {
      * and the second element contains the median distribution.
      */
     private Map<String, Number>[] getDataSet() {
-        Map<String, Number> mean = new TreeMap<>();
-        Map<String, Number> median = new TreeMap<>();
+        Map<String, Number> mean = new LinkedHashMap<>();
+        Map<String, Number> median = new LinkedHashMap<>();
         scoreMap.forEach((assessment, score) -> {
             AssessmentStatistics statistics = new AssessmentStatistics(assessment);
             mean.put(assessment.getName(), statistics.getMean());


### PR DESCRIPTION
Changes 
- Hide the tick label for 104 (see below screenshots)
- Ensure that the order of assessments in the graph matches the insertion order of assessments (see below screenshots)

## Before: 
Assessments were inserted in the order of RA1 -> RA2 -> Midterm -> Practical Assessment -> Finals, but graph displays it in sorted order (i.e. Finals -> Midterm -> PA -> RA1 -> RA2)
![image](https://user-images.githubusercontent.com/75519136/140455087-d5e8859c-d48f-4ab8-a04d-8022a893f434.png)

## After:
Order of assessments is preserved. And 104 label is hidden.
![image](https://user-images.githubusercontent.com/75519136/140455230-2371ad68-e12a-4967-ac3a-ea263704b9f4.png)

I also edited the code a bit to get rid of the unchecked warnings, hope you don't mind!